### PR TITLE
feat: migrate to makefile and add deduplicate task

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[Makefile]
+indent_style = tab

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,19 +5,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Build test suite
-        run: |
-          mkdir -p svgs/W3C_SVG_11_TestSuite dist
-          wget https://www.w3.org/Graphics/SVG/Test/20110816/archives/W3C_SVG_11_TestSuite.tar.gz
-          tar -tf W3C_SVG_11_TestSuite.tar.gz | grep -E '^svg/.+\.svgz?$' > filter.txt
-          tar -C svgs/W3C_SVG_11_TestSuite -xf W3C_SVG_11_TestSuite.tar.gz -T filter.txt
-          wget https://download.kde.org/stable/frameworks/5.113/oxygen-icons-5.113.0.tar.xz
-          tar -tf oxygen-icons-5.113.0.tar.xz | grep -E '\.svgz?$' > filter.txt
-          tar -C svgs -xf oxygen-icons-5.113.0.tar.xz -T filter.txt
-          find svgs -type l -delete
-          find svgs -type f -name "*.svgz" -exec sh -c '7z e -so {} > $(echo {} | sed s/\.svgz$/\.svg/)' \; -delete
-          find svgs -type f -exec bash -c 'if [ $(file -bi {} | sed -e "s/.* charset=//") == 'utf-16le' ]; then echo "$(iconv -f utf-16le -t utf-8 {})" > {}; fi' \;
-          tar czf dist/svgo-test-suite.tar.gz svgs/*
+        run: make build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,16 @@
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build test suite
+        run: make build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/dist/
+/svgs/
+/filter.txt
+/*.tar.*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+clean:
+	rm -rf dist
+	rm -rf svgs
+	rm -f oxygen-icons-*.tar.xz
+	rm -f W3C_SVG_11_TestSuite.tar.gz
+
+fetch-w3c-test-suite:
+	mkdir -p svgs/W3C_SVG_11_TestSuite
+	wget https://www.w3.org/Graphics/SVG/Test/20110816/archives/W3C_SVG_11_TestSuite.tar.gz --no-clobber
+	tar -tf W3C_SVG_11_TestSuite.tar.gz | grep -E '^svg/.+\.svgz?$$' > filter.txt
+	tar -C svgs/W3C_SVG_11_TestSuite -xf W3C_SVG_11_TestSuite.tar.gz -T filter.txt
+	rm filter.txt
+
+fetch-oxygen-icons:
+	mkdir -p svgs
+	wget https://download.kde.org/stable/frameworks/5.113/oxygen-icons-5.113.0.tar.xz --no-clobber
+	tar -tf oxygen-icons-5.113.0.tar.xz | grep -E '\.svgz?$$' > filter.txt
+	tar -C svgs -xf oxygen-icons-5.113.0.tar.xz -T filter.txt
+	rm filter.txt
+
+normalize:
+	find svgs -type l -delete
+	find svgs -type f -name "*.svgz" -exec sh -c '7z e -so {} > $$(echo {} | sed s/\.svgz$$/\.svg/)' \; -delete
+	find svgs -type f -exec bash -c 'if [ $$(file -bi {} | sed -e "s/.* charset=//") == 'utf-16le' ]; then echo "$$(iconv -f utf-16le -t utf-8 {})" > {}; fi' \;
+
+deduplicate:
+	@find svgs -type f | while read FILE; \
+	do \
+		HASH=$$(sha1sum $$FILE | awk "{ print \$$1 }"); \
+		if echo $$HASHES | grep $$HASH -q; then \
+			rm $$FILE; \
+		else \
+			HASHES="$$HASHES $$HASH"; \
+		fi; \
+	done;
+
+package:
+	mkdir -p dist
+	tar czf dist/svgo-test-suite.tar.gz svgs/*
+
+build:
+	make fetch-w3c-test-suite
+	make fetch-oxygen-icons
+	make normalize
+	make deduplicate
+	make package

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Here are the differences between the repack and the originals:
 * Excludes symlinks.
 * Converts SVGZ files to SVGs.
 * Includes only SVG files.
+* Deletes duplicate files.
 
 ## SVG Optimizer
 


### PR DESCRIPTION
### Deduplicate Files

Adds a build step to delete duplicate files, a test suite doesn't need these.

### Quality of Life

* Migrates the script over to a Makefile for easier maintenance.
* Splits the script over multiple commands, so each can be run independently.
* Adds `--no-clobber` to wget commands to avoid redownloading the archives if we already have them locally. (Doesn't impact CI, run `make clean` if you specifically want to fetch archives again.)
* Adds CI task on PR to try and build the archive, so we can see if it builds succesfully on GitHub before merging.

## Related

* Closes https://github.com/svg/svgo-test-suite/pull/1 (Added contributor as co-author.)