### PR TITLE
chore: include notice and author files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /dist/
-/svgs/
+/svgo-test-suite/
 /filter.txt
 /*.tar.*

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,32 @@
+ARTIFACT_NAME = svgo-test-suite
+
 clean:
 	rm -rf dist
-	rm -rf svgo-test-suite
+	rm -rf $(ARTIFACT_NAME)
 	rm -f oxygen-icons-*.tar.xz
 	rm -f W3C_SVG_11_TestSuite.tar.gz
 
 fetch-w3c-test-suite:
-	mkdir -p svgo-test-suite/W3C_SVG_11_TestSuite
+	mkdir -p $(ARTIFACT_NAME)/W3C_SVG_11_TestSuite
 	wget https://www.w3.org/Graphics/SVG/Test/20110816/archives/W3C_SVG_11_TestSuite.tar.gz --no-clobber
 	tar -tf W3C_SVG_11_TestSuite.tar.gz | grep -E '^svg/.+\.svgz?$$' > filter.txt
-	tar -C svgo-test-suite/W3C_SVG_11_TestSuite -xf W3C_SVG_11_TestSuite.tar.gz -T filter.txt
+	tar -C $(ARTIFACT_NAME)/W3C_SVG_11_TestSuite -xf W3C_SVG_11_TestSuite.tar.gz -T filter.txt
 	rm filter.txt
 
 fetch-oxygen-icons:
-	mkdir -p svgo-test-suite
+	mkdir -p $(ARTIFACT_NAME)
 	wget https://download.kde.org/stable/frameworks/5.113/oxygen-icons-5.113.0.tar.xz --no-clobber
 	tar -tf oxygen-icons-5.113.0.tar.xz | grep -E '(\.svgz?$$|/COPYING.*|/AUTHORS$$)' > filter.txt
-	tar -C svgo-test-suite -xf oxygen-icons-5.113.0.tar.xz -T filter.txt
+	tar -C $(ARTIFACT_NAME) -xf oxygen-icons-5.113.0.tar.xz -T filter.txt
 	rm filter.txt
 
 normalize:
-	find svgo-test-suite -type l -delete
-	find svgo-test-suite -type f -name "*.svgz" -exec sh -c '7z e -so {} > $$(echo {} | sed s/\.svgz$$/\.svg/)' \; -delete
-	find svgo-test-suite -type f -exec bash -c 'if [ $$(file -bi {} | sed -e "s/.* charset=//") == 'utf-16le' ]; then echo "$$(iconv -f utf-16le -t utf-8 {})" > {}; fi' \;
+	find $(ARTIFACT_NAME) -type l -delete
+	find $(ARTIFACT_NAME) -type f -name "*.svgz" -exec sh -c '7z e -so {} > $$(echo {} | sed s/\.svgz$$/\.svg/)' \; -delete
+	find $(ARTIFACT_NAME) -type f -exec bash -c 'if [ $$(file -bi {} | sed -e "s/.* charset=//") == 'utf-16le' ]; then echo "$$(iconv -f utf-16le -t utf-8 {})" > {}; fi' \;
 
 deduplicate:
-	@find svgo-test-suite -type f | while read FILE; \
+	@find $(ARTIFACT_NAME) -type f | while read FILE; \
 	do \
 		HASH=$$(sha1sum $$FILE | awk "{ print \$$1 }"); \
 		if echo $$HASHES | grep $$HASH -q; then \
@@ -36,7 +38,7 @@ deduplicate:
 
 package:
 	mkdir -p dist
-	tar czf dist/svgo-test-suite.tar.gz svgo-test-suite/*
+	tar czf dist/$(ARTIFACT_NAME).tar.gz $(ARTIFACT_NAME)/*
 
 build:
 	make fetch-w3c-test-suite

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,30 @@
 clean:
 	rm -rf dist
-	rm -rf svgs
+	rm -rf svgo-test-suite
 	rm -f oxygen-icons-*.tar.xz
 	rm -f W3C_SVG_11_TestSuite.tar.gz
 
 fetch-w3c-test-suite:
-	mkdir -p svgs/W3C_SVG_11_TestSuite
+	mkdir -p svgo-test-suite/W3C_SVG_11_TestSuite
 	wget https://www.w3.org/Graphics/SVG/Test/20110816/archives/W3C_SVG_11_TestSuite.tar.gz --no-clobber
 	tar -tf W3C_SVG_11_TestSuite.tar.gz | grep -E '^svg/.+\.svgz?$$' > filter.txt
-	tar -C svgs/W3C_SVG_11_TestSuite -xf W3C_SVG_11_TestSuite.tar.gz -T filter.txt
+	tar -C svgo-test-suite/W3C_SVG_11_TestSuite -xf W3C_SVG_11_TestSuite.tar.gz -T filter.txt
 	rm filter.txt
 
 fetch-oxygen-icons:
-	mkdir -p svgs
+	mkdir -p svgo-test-suite
 	wget https://download.kde.org/stable/frameworks/5.113/oxygen-icons-5.113.0.tar.xz --no-clobber
-	tar -tf oxygen-icons-5.113.0.tar.xz | grep -E '\.svgz?$$' > filter.txt
-	tar -C svgs -xf oxygen-icons-5.113.0.tar.xz -T filter.txt
+	tar -tf oxygen-icons-5.113.0.tar.xz | grep -E '(\.svgz?$$|/COPYING.*|/AUTHORS$$)' > filter.txt
+	tar -C svgo-test-suite -xf oxygen-icons-5.113.0.tar.xz -T filter.txt
 	rm filter.txt
 
 normalize:
-	find svgs -type l -delete
-	find svgs -type f -name "*.svgz" -exec sh -c '7z e -so {} > $$(echo {} | sed s/\.svgz$$/\.svg/)' \; -delete
-	find svgs -type f -exec bash -c 'if [ $$(file -bi {} | sed -e "s/.* charset=//") == 'utf-16le' ]; then echo "$$(iconv -f utf-16le -t utf-8 {})" > {}; fi' \;
+	find svgo-test-suite -type l -delete
+	find svgo-test-suite -type f -name "*.svgz" -exec sh -c '7z e -so {} > $$(echo {} | sed s/\.svgz$$/\.svg/)' \; -delete
+	find svgo-test-suite -type f -exec bash -c 'if [ $$(file -bi {} | sed -e "s/.* charset=//") == 'utf-16le' ]; then echo "$$(iconv -f utf-16le -t utf-8 {})" > {}; fi' \;
 
 deduplicate:
-	@find svgs -type f | while read FILE; \
+	@find svgo-test-suite -type f | while read FILE; \
 	do \
 		HASH=$$(sha1sum $$FILE | awk "{ print \$$1 }"); \
 		if echo $$HASHES | grep $$HASH -q; then \
@@ -36,7 +36,7 @@ deduplicate:
 
 package:
 	mkdir -p dist
-	tar czf dist/svgo-test-suite.tar.gz svgs/*
+	tar czf dist/svgo-test-suite.tar.gz svgo-test-suite/*
 
 build:
 	make fetch-w3c-test-suite


### PR DESCRIPTION
Includes LICENSE/NOTICE/AUTHORS/COPYING files from the packages we aggregate. This should've been included in the first place, and it would go against the license to not bundle the license in any works that include the SVGs.

While we're at it, I renamed the artifact from `svgs` to `svgo-test-suite` since it no longer only contains SVGs. (I've also made this a variable so it's easier to rename in future should the need ever arise.)