### PR TITLE
chore: upgrade oxygen icons to 5.116.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 ARTIFACT_NAME = svgo-test-suite
+OXYGEN_ICONS_VERSION = 5.116
 
 clean:
 	rm -rf dist
@@ -15,9 +16,9 @@ fetch-w3c-test-suite:
 
 fetch-oxygen-icons:
 	mkdir -p $(ARTIFACT_NAME)
-	wget https://download.kde.org/stable/frameworks/5.113/oxygen-icons-5.113.0.tar.xz --no-clobber
-	tar -tf oxygen-icons-5.113.0.tar.xz | grep -E '(\.svgz?$$|/COPYING.*|/AUTHORS$$)' > filter.txt
-	tar -C $(ARTIFACT_NAME) -xf oxygen-icons-5.113.0.tar.xz -T filter.txt
+	wget https://download.kde.org/stable/frameworks/$(OXYGEN_ICONS_VERSION)/oxygen-icons-$(OXYGEN_ICONS_VERSION).0.tar.xz --no-clobber
+	tar -tf oxygen-icons-$(OXYGEN_ICONS_VERSION).0.tar.xz | grep -E '(\.svgz?$$|/COPYING.*|/AUTHORS$$)' > filter.txt
+	tar -C $(ARTIFACT_NAME) -xf oxygen-icons-$(OXYGEN_ICONS_VERSION).0.tar.xz -T filter.txt
 	rm filter.txt
 
 normalize:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The contents of the archive will be optimized for the pull request pipelines of 
 | Source | License |
 |---|---|
 | [W3C SVG 1.1 Test Suite](https://www.w3.org/Graphics/SVG/Test/20110816/) | [W3C test suite license](https://www.w3.org/copyright/test-suite-license-2023) |
-| [KDE Oxygen Icons](https://download.kde.org/stable/frameworks/5.113/oxygen-icons-5.113.0.tar.xz.mirrorlist) | [LGPL-3.0](https://invent.kde.org/frameworks/oxygen-icons/-/blob/master/COPYING) |
+| [KDE Oxygen Icons](https://download.kde.org/stable/frameworks/5.116/oxygen-icons-5.116.0.tar.xz.mirrorlist) | [LGPL-3.0](https://invent.kde.org/frameworks/oxygen-icons/-/blob/master/COPYING) |
 
 ## Processing
 


### PR DESCRIPTION
Updates Oxygen Icons to version 5.116.0.

No particular reason. While I was amending the pipeline for the SVGO Test Suite, figured we might as well update the the latest version of the icons too.