### PR TITLE
chore: add reuse and generate bom in archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,8 @@ WIKIMEDIA_DIR = $(ARTIFACT_NAME)/wikimedia-commons
 WGET_OPTIONS = --no-clobber --no-verbose
 
 clean:
-	rm -rf dist
-	rm -rf $(ARTIFACT_NAME)
-	rm -f oxygen-icons-*.tar.xz
-	rm -f W3C_SVG_11_TestSuite.tar.gz
+	rm -rf dist $(ARTIFACT_NAME)
+	rm -f oxygen-icons-*.tar.xz W3C_SVG_11_TestSuite.tar.gz
 
 fetch-w3c-test-suite:
 	mkdir -p $(ARTIFACT_NAME)/W3C_SVG_11_TestSuite
@@ -50,6 +48,16 @@ deduplicate:
 		fi; \
 	done;
 
+licenses:
+	if [ ! -d ".venv" ]; then python3 -m venv .venv; fi
+	. .venv/bin/activate
+	pip3 install reuse
+	cp -r static/* $(ARTIFACT_NAME)
+	reuse --root $(ARTIFACT_NAME) download --all
+	reuse --root $(ARTIFACT_NAME) lint
+	reuse --root $(ARTIFACT_NAME) spdx -o $(ARTIFACT_NAME)/reuse.spdx
+	rm $(ARTIFACT_NAME)/REUSE.toml
+
 package:
 	mkdir -p dist
 	tar czf dist/$(ARTIFACT_NAME).tar.gz $(ARTIFACT_NAME)/*
@@ -60,4 +68,5 @@ build:
 	make fetch-wikimedia-commons
 	make normalize
 	make deduplicate
+	make licenses
 	make package

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SVGO Test Suite [![chat](https://img.shields.io/discord/815166721315831868)](https://discord.gg/z8jX8NYxrE)
+# SVGO Test Suite [![](https://img.shields.io/discord/815166721315831868)](https://discord.gg/z8jX8NYxrE)
 
 Scripts for building a test suite of SVGs from multiple sources. The aim is to maintain an archive that's convenient and relatively efficient to pull from CI pipelines to run regression tests.
 
@@ -6,15 +6,15 @@ The contents of the archive will be optimized for the pull request pipelines of 
 
 ## Sources
 
-| Source | License |
-|---|---|
-| [W3C SVG 1.1 Test Suite](https://www.w3.org/Graphics/SVG/Test/20110816/) | [W3C test suite license](https://www.w3.org/copyright/test-suite-license-2023) |
-| [KDE Oxygen Icons](https://download.kde.org/stable/frameworks/5.116/oxygen-icons-5.116.0.tar.xz.mirrorlist) | [LGPL-3.0](https://invent.kde.org/frameworks/oxygen-icons/-/blob/master/COPYING) |
-| [Wikimedia Icons](https://commons.wikimedia.org/wiki/Main_Page) | TBD |
+SVGO Test Suite includes files from the following sources. We use [REUSE](https://reuse.software/) to annotate each file with the respective license, attribution, and copyright information within the distributed archive.
+
+* [W3C SVG 1.1 Test Suite](https://www.w3.org/Graphics/SVG/Test/20110816/)
+* [KDE Oxygen Icons](https://download.kde.org/stable/frameworks/5.116/oxygen-icons-5.116.0.tar.xz.mirrorlist)
+* [Wikimedia Commons](https://commons.wikimedia.org/wiki/Category:Large_SVG_files)
 
 ## Processing
 
-Here are the differences between the repack and the originals:
+Here are the differences between the repack and the original SVGs:
 
 * Exclude symlinks.
 * Convert SVGZ files to SVGs.

--- a/static/LICENSES/LicenseRef-oxygen-icons-LGPL-3.0-only.txt
+++ b/static/LICENSES/LicenseRef-oxygen-icons-LGPL-3.0-only.txt
@@ -1,0 +1,216 @@
+The Oxygen Icon Theme
+    Copyright (C) 2007 Nuno Pinheiro <nuno@oxygen-icons.org>
+    Copyright (C) 2007 David Vignoni <david@icon-king.com>
+    Copyright (C) 2007 David Miller <miller@oxygen-icons.org>
+    Copyright (C) 2007 Johann Ollivier Lapeyre <johann@oxygen-icons.org>
+    Copyright (C) 2007 Kenneth Wimer <kwwii@bootsplash.org>
+    Copyright (C) 2007 Riccardo Iaconelli <riccardo@oxygen-icons.org>
+
+
+and others
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 3 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+Clarification:
+
+  The GNU Lesser General Public License or LGPL is written for
+  software libraries in the first place. We expressly want the LGPL to
+  be valid for this artwork library too.
+
+  KDE Oxygen theme icons is a special kind of software library, it is an
+  artwork library, it's elements can be used in a Graphical User Interface, or
+  GUI.
+
+  Source code, for this library means:
+   - where they exist, SVG;
+   - otherwise, if applicable, the multi-layered formats xcf or psd, or
+  otherwise png.
+
+  The LGPL in some sections obliges you to make the files carry
+  notices. With images this is in some cases impossible or hardly useful.
+
+  With this library a notice is placed at a prominent place in the directory
+  containing the elements. You may follow this practice.
+
+  The exception in section 5 of the GNU Lesser General Public License covers
+  the use of elements of this art library in a GUI.
+
+  kde-artists [at] kde.org
+
+-----
+		   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/static/LICENSES/LicenseRef-w3c-test-suite-license-2023.txt
+++ b/static/LICENSES/LicenseRef-w3c-test-suite-license-2023.txt
@@ -1,0 +1,61 @@
+This document, test suites and other documents that link to this statement are
+provided by the copyright holders under the following license.
+
+## License
+
+By using and/or copying this document, or the W3C document from which this
+statement is linked, you (the licensee) agree that you have read, understood,
+and will comply with the following terms and conditions:
+
+Permission to copy, and distribute the contents of this document, or the W3C
+document from which this statement is linked, in any medium for any purpose and
+without fee or royalty is hereby granted, provided that you include the
+following on *ALL* copies of the document, or portions thereof, that you use:
+
+1.  A link or URL to the original W3C document.
+
+2.  The pre-existing copyright
+notice of the original author, or if it doesn't exist, a notice (hypertext is
+preferred, but a textual representation is permitted) of the form: "Copyright ©
+\[$year-of-document\] [World Wide Web Consortium](https://www.w3.org/). All
+Rights Reserved.
+[https://www.w3.org/copyright/test-suite-license-2023/](https://www.w3.org/copyright/test-suite-license-2023/)"
+
+3.  *If it exists*, the STATUS of the W3C document.
+
+When space permits, inclusion of the full text of this **NOTICE** should be
+provided. We request that authorship attribution be provided in any software,
+documents, or other items or products that you create pursuant to the
+implementation of the contents of this document, or any portion thereof.
+
+No right to create modifications or derivatives of W3C documents is granted
+pursuant to this license. However, if additional requirements (documented in
+the [Copyright FAQ](https://www.w3.org/copyright/intellectual-rights/)) are
+satisfied, the right to create modifications or derivatives is sometimes
+granted by W3C to individuals complying with those requirements.
+
+If a test suite distinguishes the test harness (or, framework for navigation)
+and the actual tests, permission is given to remove or alter the harness or
+navigation if the test suite in question allows to do so. The tests themselves
+shall NOT be changed in any way.
+
+The name and trademarks of W3C and other copyright holders may NOT be used in
+advertising or publicity pertaining to this document or other documents that
+link to this statement without specific, written prior permission. Title to
+copyright in this document will at all times remain with copyright holders.
+Permission is given to use the trademarked string W3C within claims of
+performance concerning W3C Specifications or features described therein, and
+there only, if the test suite so authorizes.
+
+## Disclaimers
+
+THIS WORK IS PROVIDED BY W3C, THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL W3C, THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/static/REUSE.toml
+++ b/static/REUSE.toml
@@ -1,0 +1,52 @@
+version = 1
+
+[[annotations]]
+path = ["oxygen-icons-*/**"]
+SPDX-FileCopyrightText = "See AUTHORS, COPYING, and COPYING.LIB in oxygen-icons-5.116.0"
+SPDX-License-Identifier = "LicenseRef-oxygen-icons-LGPL-3.0-only"
+
+[[annotations]]
+path = ["W3C_SVG_11_TestSuite/**"]
+precedence = "override"
+SPDX-FileCopyrightText = "Copyright © 2023 World Wide Web Consortium. All Rights Reserved. https://www.w3.org/copyright/test-suite-license-2023/"
+SPDX-License-Identifier = "LicenseRef-w3c-test-suite-license-2023"
+
+[[annotations]]
+path = ["wikimedia-commons/1_42_polytope_7-cube.svg"]
+SPDX-FileCopyrightText = "NONE"
+SPDX-License-Identifier = "CC0-1.0"
+
+[[annotations]]
+path = ["wikimedia-commons/Aegean_sea_Anatolia_and_Armenian_highlands_regions_large_topographic_basemap.svg"]
+SPDX-FileCopyrightText = "Copyright © ikonact using data from NASA SRTM3 v2 and SWBD"
+SPDX-License-Identifier = "CC-BY-SA-4.0"
+
+[[annotations]]
+path = ["wikimedia-commons/Germany___districts__municipalities__location_map_current.svg"]
+SPDX-FileCopyrightText = "© GeoBasis-DE / BKG 2013 according Verordnung zur Festlegung der Nutzungsbestimmungen für die Bereitstellung von Geodaten des Bundes vom 19. März 2013 (BGBl. I S. 547) (GEoNutzV)"
+SPDX-License-Identifier = "CC-BY-SA-3.0"
+
+[[annotations]]
+path = ["wikimedia-commons/Italy_-_Regions_and_provinces.svg"]
+SPDX-FileCopyrightText = "Copyright © M.casanova using data from Confini delle unità amministrative a fini statistici"
+SPDX-License-Identifier = "CC-BY-SA-4.0"
+
+[[annotations]]
+path = ["wikimedia-commons/Mapa_do_Brasil_por_c_digo_DDD.svg"]
+SPDX-FileCopyrightText = "Copyright © João Vitor Bachini"
+SPDX-License-Identifier = "CC-BY-SA-4.0"
+
+[[annotations]]
+path = ["wikimedia-commons/Propane_flame_contours-en.svg"]
+SPDX-FileCopyrightText = "Copyright © KDS444"
+SPDX-License-Identifier = "CC-BY-SA-3.0"
+
+[[annotations]]
+path = ["wikimedia-commons/Saariston_Rengastie_route_labels.svg"]
+SPDX-FileCopyrightText = "Copyright © Nelg"
+SPDX-License-Identifier = "CC-BY-SA-4.0"
+
+[[annotations]]
+path = ["wikimedia-commons/Spain_languages-de.svg"]
+SPDX-FileCopyrightText = "Copyright © Órbigo"
+SPDX-License-Identifier = "GFDL-1.2-only"


### PR DESCRIPTION
While SVGO doesn't use the license files in any way, since we are repacking other peoples work, we need to make sure we're attributing the files correctly in our distributed archive.

We use [REUSE](https://reuse.software/), a standard, and tool by the FSFE for documenting the licenses in a project.

This amends the pipeline to download appropriate licenses and generate a `reuse.spdx` file that lists every file in the archive and their respective author/copyright/license information to the best that we could document it.

So this means the output of the archive now contains two new top-level items:

* `LICENSES`, a directory containing the full license text for every license a piece of work is under.
* `reuse.spdx`, the result of running `reuse spdx` which generates a bill of materials, and explicitly notes each file one by one, with the copyright holder and license information.

The following is an excerpt from the generated `reuse.spdx` file for demonstrative purposes:

```spdx
…
FileName: ./oxygen-icons-5.116.0/scalable/text-formatting.svg
SPDXID: SPDXRef-d0c18f5676a351fd8f6e94643b3f3cf5
FileChecksum: SHA1: 70067e300651958820dccca3a49c2891247928b9
LicenseConcluded: NOASSERTION
LicenseInfoInFile: LicenseRef-oxygen-icons-LGPL-3.0-only
FileCopyrightText: <text>See AUTHORS, COPYING, and COPYING.LIB in oxygen-icons-5.116.0</text>

FileName: ./wikimedia-commons/1_42_polytope_7-cube.svg
SPDXID: SPDXRef-b91f41c4c0b2cd5e8bab2843855c5641
FileChecksum: SHA1: 348631ef68900a2fe5ebbbeb3c691a6c3f800393
LicenseConcluded: NOASSERTION
LicenseInfoInFile: CC0-1.0
FileCopyrightText: <text>NONE</text>

FileName: ./wikimedia-commons/Aegean_sea_Anatolia_and_Armenian_highlands_regions_large_topographic_basemap.svg
SPDXID: SPDXRef-152098cc530284873bc7fd924cd99bea
FileChecksum: SHA1: 4a41039db52708ceafa297a12a8333d441865fc3
LicenseConcluded: NOASSERTION
LicenseInfoInFile: CC-BY-SA-4.0
FileCopyrightText: <text>Copyright © ikonact using data from NASA SRTM3 v2 and SWBD</text>

FileName: ./wikimedia-commons/Germany___districts__municipalities__location_map_current.svg
SPDXID: SPDXRef-51ab71757dde7d8c3a7753743c831fc3
FileChecksum: SHA1: c0dd0b255e34e112c52ad8c983bb6b5680083dbd
LicenseConcluded: NOASSERTION
LicenseInfoInFile: CC-BY-SA-3.0
FileCopyrightText: <text>© GeoBasis-DE / BKG 2013 according Verordnung zur Festlegung der Nutzungsbestimmungen für die Bereitstellung von Geodaten des Bundes vom 19. März 2013 (BGBl. I S. 547) (GEoNutzV)</text>

FileName: ./wikimedia-commons/Italy_-_Regions_and_provinces.svg
SPDXID: SPDXRef-2f9de9a25a497dc3db807a74dc7814d3
FileChecksum: SHA1: 2ba06fbbd1318e9e39438a641c42137782024fe3
LicenseConcluded: NOASSERTION
LicenseInfoInFile: CC-BY-SA-4.0
FileCopyrightText: <text>Copyright © M.casanova using data from Confini delle unità amministrative a fini statistici</text>
…
```