### PR TITLE
feat: add version file to test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ licenses:
 	)
 	rm $(ARTIFACT_NAME)/REUSE.toml
 
+version:
+	find $(ARTIFACT_NAME) -name '*.svg' -exec md5sum {} \; | sort | md5sum | awk '{ print $$1 }' > $(ARTIFACT_NAME)/VERSION
+
 package:
 	mkdir -p dist
 	tar czf dist/$(ARTIFACT_NAME).tar.gz $(ARTIFACT_NAME)/*
@@ -70,5 +73,6 @@ build:
 	make fetch-wikimedia-commons
 	make normalize
 	make deduplicate
+	make version
 	make licenses
 	make package

--- a/static/REUSE.toml
+++ b/static/REUSE.toml
@@ -1,6 +1,11 @@
 version = 1
 
 [[annotations]]
+path = "VERSION"
+SPDX-FileCopyrightText = "SVGO and Contributors"
+SPDX-License-Identifier = "CC0-1.0"
+
+[[annotations]]
 path = "oxygen-icons-*/**"
 SPDX-FileCopyrightText = "See AUTHORS, COPYING, and COPYING.LIB in oxygen-icons-5.116.0"
 SPDX-License-Identifier = "LicenseRef-oxygen-icons-LGPL-3.0-only"
@@ -32,7 +37,7 @@ SPDX-FileCopyrightText = "Copyright © M.casanova using data from Confini delle 
 SPDX-License-Identifier = "CC-BY-SA-4.0"
 
 [[annotations]]
-path = "wikimedia-commons/Mapa_do_Brasil_por_c_digo_DDD.svg"
+path = "wikimedia-commons/Mapa_do_Brasil_por_c*.svg"
 SPDX-FileCopyrightText = "Copyright © João Vitor Bachini"
 SPDX-License-Identifier = "CC-BY-SA-4.0"
 


### PR DESCRIPTION
We need to start tracking a version for SVGO Test Suite.

Given its usage, I don't believe it's worth a conventional versioning system like semantic versioning. We don't need to document details like if it's a minor or major change, and it doesn't matter if a version came before or after another.

The only thing that matters is if two versions of SVGO Test Suite have the same content or not.

This is best solved with checksums, so we'll use the checksum algorithm on Ubuntu that has a result with the least bytes/characters.  

The version will be an MD5 hash like `e883d5ff9ca807d9da7a892ea973c11d`.

The goal is to be able to store the version when running regression tests, and then compare results for later regression test runs. The regression test report will store the SVGO Test Suite version so it can confirm that the version matches, as it would not be a fair comparison if the tests were run against different files.

## Implementation

* MD5 checksum of every SVG.
* Sort the list by checksum, or if the checksum matches then by filename.
* MD5 checksum the list of MD5 checksums.

## Related

* https://github.com/svg/svgo/issues/2160