### PR TITLE
chore: sort files before deleting duplicates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ normalize:
 	find $(ARTIFACT_NAME) -type f -exec bash -c 'if [ $$(file -bi {} | sed -e "s/.* charset=//") == 'utf-16le' ]; then echo "$$(iconv -f utf-16le -t utf-8 {})" > {}; fi' \;
 
 deduplicate:
-	@find $(ARTIFACT_NAME) -type f | while read FILE; \
+	@find $(ARTIFACT_NAME) -type f | sort | while read FILE; \
 	do \
 		HASH=$$(sha1sum $$FILE | awk "{ print \$$1 }"); \
 		if echo $$HASHES | grep $$HASH -q; then \


### PR DESCRIPTION
We have a step to delete duplicate SVGs from inside the directory. The problem is that depending on the order that `find` returned files in, which one actually got deleted could vary.

When all tests pass, this doesn't matter. But when we have the file in one of our files lists (`expect-mismatch`, `ignore`, or `skip`), then it can be a problem if the in subsequent builds of the Test Suite a different duplicate was deleted.

Adds `sort` to increase the reproducibility of SVGO Test Suite.

I believe this was the cause of sometimes new files being "fixed" or "breaking" randomly, it's when one of the known files that break end up with a new name.

An alternative fix could've been to simply name all files after their MD5 hash, but these solutions seem to be enough. It's nice to be able to refer to files by name anyway, and is better to be able to attribute a file by name too.