### PR TITLE
chores: use md5sum and reduce stdout

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,7 @@
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main

--- a/Makefile
+++ b/Makefile
@@ -4,43 +4,47 @@ WIKIMEDIA_DIR = $(ARTIFACT_NAME)/wikimedia-commons
 WGET_OPTIONS = --no-clobber --no-verbose
 
 clean:
-	rm -rf dist $(ARTIFACT_NAME)
-	rm -f oxygen-icons-*.tar.xz W3C_SVG_11_TestSuite.tar.gz
+	@rm -rf dist $(ARTIFACT_NAME)
+	@rm -f oxygen-icons-*.tar.xz W3C_SVG_11_TestSuite.tar.gz
 
 fetch-w3c-test-suite:
-	mkdir -p $(ARTIFACT_NAME)/W3C_SVG_11_TestSuite
-	wget $(WGET_OPTIONS) https://www.w3.org/Graphics/SVG/Test/20110816/archives/W3C_SVG_11_TestSuite.tar.gz
-	tar -tf W3C_SVG_11_TestSuite.tar.gz | grep -E '^svg/.+\.svgz?$$' > filter.txt
-	tar -C $(ARTIFACT_NAME)/W3C_SVG_11_TestSuite -xf W3C_SVG_11_TestSuite.tar.gz -T filter.txt
-	rm filter.txt
+	@mkdir -p $(ARTIFACT_NAME)/W3C_SVG_11_TestSuite
+	@wget $(WGET_OPTIONS) https://www.w3.org/Graphics/SVG/Test/20110816/archives/W3C_SVG_11_TestSuite.tar.gz
+	@tar -tf W3C_SVG_11_TestSuite.tar.gz | grep -E '^svg/.+\.svgz?$$' > filter.txt
+	@tar -C $(ARTIFACT_NAME)/W3C_SVG_11_TestSuite -xf W3C_SVG_11_TestSuite.tar.gz -T filter.txt
+	@rm filter.txt
 
 fetch-oxygen-icons:
-	mkdir -p $(ARTIFACT_NAME)
-	wget $(WGET_OPTIONS) https://download.kde.org/stable/frameworks/$(OXYGEN_ICONS_VERSION)/oxygen-icons-$(OXYGEN_ICONS_VERSION).0.tar.xz
-	tar -tf oxygen-icons-$(OXYGEN_ICONS_VERSION).0.tar.xz | grep -E '(\.svgz?$$|/COPYING.*|/AUTHORS$$)' > filter.txt
-	tar -C $(ARTIFACT_NAME) -xf oxygen-icons-$(OXYGEN_ICONS_VERSION).0.tar.xz -T filter.txt
-	rm filter.txt
+	@mkdir -p $(ARTIFACT_NAME)
+	@wget $(WGET_OPTIONS) https://download.kde.org/stable/frameworks/$(OXYGEN_ICONS_VERSION)/oxygen-icons-$(OXYGEN_ICONS_VERSION).0.tar.xz
+	@tar -tf oxygen-icons-$(OXYGEN_ICONS_VERSION).0.tar.xz | grep -E '(\.svgz?$$|/COPYING.*|/AUTHORS$$)' > filter.txt
+	@tar -C $(ARTIFACT_NAME) -xf oxygen-icons-$(OXYGEN_ICONS_VERSION).0.tar.xz -T filter.txt
+	@rm filter.txt
 
 fetch-wikimedia-commons:
-	wget $(WGET_OPTIONS) "https://upload.wikimedia.org/wikipedia/commons/a/a1/Spain_languages-de.svg" --directory-prefix $(WIKIMEDIA_DIR)
-	wget $(WGET_OPTIONS) "https://upload.wikimedia.org/wikipedia/commons/d/d1/Saariston_Rengastie_route_labels.svg" --directory-prefix $(WIKIMEDIA_DIR)
-	wget $(WGET_OPTIONS) "https://upload.wikimedia.org/wikipedia/commons/5/5a/Mapa_do_Brasil_por_c%C3%B3digo_DDD.svg" --directory-prefix $(WIKIMEDIA_DIR)
-	wget $(WGET_OPTIONS) "https://upload.wikimedia.org/wikipedia/commons/c/c1/Propane_flame_contours-en.svg" --directory-prefix $(WIKIMEDIA_DIR)
-	wget $(WGET_OPTIONS) "https://upload.wikimedia.org/wikipedia/commons/f/ff/1_42_polytope_7-cube.svg" --directory-prefix $(WIKIMEDIA_DIR)
-	wget $(WGET_OPTIONS) "https://upload.wikimedia.org/wikipedia/commons/f/fd/Germany_%28%2Bdistricts_%2Bmunicipalities%29_location_map_current.svg" --directory-prefix $(WIKIMEDIA_DIR)
-	wget $(WGET_OPTIONS) "https://upload.wikimedia.org/wikipedia/commons/7/7f/Italy_-_Regions_and_provinces.svg" --directory-prefix $(WIKIMEDIA_DIR)
-	wget $(WGET_OPTIONS) "https://upload.wikimedia.org/wikipedia/commons/6/60/Aegean_sea_Anatolia_and_Armenian_highlands_regions_large_topographic_basemap.svg" --directory-prefix $(WIKIMEDIA_DIR)
+	@wget $(WGET_OPTIONS) "https://upload.wikimedia.org/wikipedia/commons/a/a1/Spain_languages-de.svg" --directory-prefix $(WIKIMEDIA_DIR)
+	@wget $(WGET_OPTIONS) "https://upload.wikimedia.org/wikipedia/commons/d/d1/Saariston_Rengastie_route_labels.svg" --directory-prefix $(WIKIMEDIA_DIR)
+	@wget $(WGET_OPTIONS) "https://upload.wikimedia.org/wikipedia/commons/5/5a/Mapa_do_Brasil_por_c%C3%B3digo_DDD.svg" --directory-prefix $(WIKIMEDIA_DIR)
+	@wget $(WGET_OPTIONS) "https://upload.wikimedia.org/wikipedia/commons/c/c1/Propane_flame_contours-en.svg" --directory-prefix $(WIKIMEDIA_DIR)
+	@wget $(WGET_OPTIONS) "https://upload.wikimedia.org/wikipedia/commons/f/ff/1_42_polytope_7-cube.svg" --directory-prefix $(WIKIMEDIA_DIR)
+	@wget $(WGET_OPTIONS) "https://upload.wikimedia.org/wikipedia/commons/f/fd/Germany_%28%2Bdistricts_%2Bmunicipalities%29_location_map_current.svg" --directory-prefix $(WIKIMEDIA_DIR)
+	@wget $(WGET_OPTIONS) "https://upload.wikimedia.org/wikipedia/commons/7/7f/Italy_-_Regions_and_provinces.svg" --directory-prefix $(WIKIMEDIA_DIR)
+	@wget $(WGET_OPTIONS) "https://upload.wikimedia.org/wikipedia/commons/6/60/Aegean_sea_Anatolia_and_Armenian_highlands_regions_large_topographic_basemap.svg" --directory-prefix $(WIKIMEDIA_DIR)
 
 normalize:
-	find $(ARTIFACT_NAME) -type l -delete
-	find $(ARTIFACT_NAME) -type f -exec bash -c 'mv "{}" $$(echo "{}" | sed "s:[^a-zA-Z0-9./_-]:_:g")' \;
-	find $(ARTIFACT_NAME) -type f -name "*.svgz" -exec sh -c '7z e -so {} > $$(echo {} | sed s/\.svgz$$/\.svg/)' \; -delete
-	find $(ARTIFACT_NAME) -type f -exec bash -c 'if [ $$(file -bi {} | sed -e "s/.* charset=//") == 'utf-16le' ]; then echo "$$(iconv -f utf-16le -t utf-8 {})" > {}; fi' \;
+	@find $(ARTIFACT_NAME) -type l -delete
+	@find $(ARTIFACT_NAME) -type f | while read FILE; \
+	do \
+		NEW_NAME=$$(echo "$$FILE" | sed "s:[^a-zA-Z0-9./_-]:_:g"); \
+		if [ "$$FILE" != "$$NEW_NAME" ]; then mv "$$FILE" "$$NEW_NAME"; fi; \
+	done;
+	@find $(ARTIFACT_NAME) -type f -name "*.svgz" -exec sh -c '7z e -so {} > $$(echo {} | sed s/\.svgz$$/\.svg/)' \; -delete
+	@find $(ARTIFACT_NAME) -type f -exec bash -c 'if [ $$(file -bi {} | sed -e "s/.* charset=//") == 'utf-16le' ]; then echo "$$(iconv -f utf-16le -t utf-8 {})" > {}; fi' \;
 
 deduplicate:
 	@find $(ARTIFACT_NAME) -type f | while read FILE; \
 	do \
-		HASH=$$(sha1sum $$FILE | awk "{ print \$$1 }"); \
+		HASH=$$(md5sum $$FILE | awk "{ print \$$1 }"); \
 		if echo $$HASHES | grep $$HASH -q; then \
 			rm $$FILE; \
 		else \
@@ -49,8 +53,8 @@ deduplicate:
 	done;
 
 licenses:
-	if [ ! -d ".venv" ]; then python3 -m venv .venv; fi
-	( \
+	@if [ ! -d ".venv" ]; then python3 -m venv .venv; fi
+	@( \
 		. .venv/bin/activate; \
 		pip3 -q install reuse; \
 		cp -r static/* $(ARTIFACT_NAME); \
@@ -58,21 +62,21 @@ licenses:
 		reuse --root $(ARTIFACT_NAME) lint; \
 		reuse --root $(ARTIFACT_NAME) spdx -o $(ARTIFACT_NAME)/reuse.spdx; \
 	)
-	rm $(ARTIFACT_NAME)/REUSE.toml
+	@rm $(ARTIFACT_NAME)/REUSE.toml
 
 version:
-	find $(ARTIFACT_NAME) -name '*.svg' -exec md5sum {} \; | sort | md5sum | awk '{ print $$1 }' > $(ARTIFACT_NAME)/VERSION
+	@find $(ARTIFACT_NAME) -name '*.svg' -exec md5sum {} \; | sort | md5sum | awk '{ print $$1 }' > $(ARTIFACT_NAME)/VERSION
 
 package:
-	mkdir -p dist
-	tar czf dist/$(ARTIFACT_NAME).tar.gz $(ARTIFACT_NAME)/*
+	@mkdir -p dist
+	@tar czf dist/$(ARTIFACT_NAME).tar.gz $(ARTIFACT_NAME)/*
 
 build:
-	make fetch-w3c-test-suite
-	make fetch-oxygen-icons
-	make fetch-wikimedia-commons
-	make normalize
-	make deduplicate
-	make version
-	make licenses
-	make package
+	@make fetch-w3c-test-suite
+	@make fetch-oxygen-icons
+	@make fetch-wikimedia-commons
+	@make normalize
+	@make deduplicate
+	@make version
+	@make licenses
+	@make package


### PR DESCRIPTION
Does a couple of chores, as each is quite small I opted to do it in a single commit.

## Deploy on merge with `main`

Rather than deploy manually upon merging with `main`, let's deploy automatically.

Originally I didn't do that because it wasn't always necessary, but actually we'd want this most of the time anyway, so I'd rather in rare instances have it run when it's not necessary than have to do it manually each time.

## Reduce logs

* Prefixes every command with `@` so the command itself isn't logged to the console.
* In `normalize`, we now do the `mv` conditionally so that we aren't flooded with thousands of warnings for trying to move the file to the same location.

I've intentionally left all STDOUT that's output by the underlying programs we use. I did not feel the need to silence it.

I did not feel the need to add any explicit logs with what is happening. Any STDOUT by existing commands seems to be enough to guide users/contributors.

## `md5sum` instead of `sha1sum` in deduplicate

There's no reason for this really. We just use md5sum elsewhere in the Makefile, and both achieve desirable results for our use case.

I figured we could just stick with a single checksum binary instead of 2.