### PR TITLE
chore: deploy test suite on merge

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,4 +1,7 @@
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,4 @@
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
I made a mistake in my previous PR. I wanted to run the deploy job on merge, but instead I ran out PR checks on merge.

This moves the `push.branches` property from `pr.yml` to `build-and-deploy.yml` where I'd intended it to go.

## Related

* Issue introduced in https://github.com/svg/svgo-test-suite/pull/11