### PR TITLE
feat: add Charm Icons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 ARTIFACT_NAME = svgo-test-suite
 OXYGEN_ICONS_VERSION = 5.116
+CHARM_ICONS_VERSION = 0.18.0
 WIKIMEDIA_DIR = $(ARTIFACT_NAME)/wikimedia-commons
 WGET_OPTIONS = --no-clobber --no-verbose
 
 clean:
 	@rm -rf dist $(ARTIFACT_NAME)
-	@rm -f oxygen-icons-*.tar.xz W3C_SVG_11_TestSuite.tar.gz
+	@rm -f oxygen-icons-*.tar.xz charm-icons-*.tar.gz W3C_SVG_11_TestSuite.tar.gz
 
 fetch-w3c-test-suite:
 	@mkdir -p $(ARTIFACT_NAME)/W3C_SVG_11_TestSuite
@@ -20,6 +21,12 @@ fetch-oxygen-icons:
 	@tar -tf oxygen-icons-$(OXYGEN_ICONS_VERSION).0.tar.xz | grep -E '(\.svgz?$$|/COPYING.*|/AUTHORS$$)' > filter.txt
 	@tar -C $(ARTIFACT_NAME) -xf oxygen-icons-$(OXYGEN_ICONS_VERSION).0.tar.xz -T filter.txt
 	@rm filter.txt
+
+fetch-charm-icons:
+	@mkdir -p $(ARTIFACT_NAME)
+	@wget --no-verbose -O charm-icons-$(CHARM_ICONS_VERSION).tar.gz https://github.com/jaynewey/charm-icons/archive/refs/tags/v$(CHARM_ICONS_VERSION).tar.gz
+	@tar -C $(ARTIFACT_NAME) -xf charm-icons-$(CHARM_ICONS_VERSION).tar.gz
+	@find $(ARTIFACT_NAME)/charm-icons-$(CHARM_ICONS_VERSION) -mindepth 1 -maxdepth 1 ! -name icons ! -name LICENSE -exec rm -rf {} +
 
 fetch-wikimedia-commons:
 	@wget $(WGET_OPTIONS) "https://upload.wikimedia.org/wikipedia/commons/a/a1/Spain_languages-de.svg" --directory-prefix $(WIKIMEDIA_DIR)
@@ -71,4 +78,4 @@ package:
 	@mkdir -p dist
 	@tar czf dist/$(ARTIFACT_NAME).tar.gz $(ARTIFACT_NAME)/*
 
-build: fetch-w3c-test-suite fetch-oxygen-icons fetch-wikimedia-commons normalize deduplicate version licenses package
+build: fetch-w3c-test-suite fetch-oxygen-icons fetch-charm-icons fetch-wikimedia-commons normalize deduplicate version licenses package

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,9 @@ fetch-oxygen-icons:
 fetch-charm-icons:
 	@mkdir -p $(ARTIFACT_NAME)
 	@wget --no-verbose -O charm-icons-$(CHARM_ICONS_VERSION).tar.gz https://github.com/jaynewey/charm-icons/archive/refs/tags/v$(CHARM_ICONS_VERSION).tar.gz
-	@tar -C $(ARTIFACT_NAME) -xf charm-icons-$(CHARM_ICONS_VERSION).tar.gz
-	@find $(ARTIFACT_NAME)/charm-icons-$(CHARM_ICONS_VERSION) -mindepth 1 -maxdepth 1 ! -name icons ! -name LICENSE -exec rm -rf {} +
+	@tar -tf charm-icons-$(CHARM_ICONS_VERSION).tar.gz | grep -E '^charm-icons-$(CHARM_ICONS_VERSION)/(.+\.svgz?|LICENSE)$$' > filter.txt
+	@tar -C $(ARTIFACT_NAME) -xf charm-icons-$(CHARM_ICONS_VERSION).tar.gz -T filter.txt
+	@rm filter.txt
 
 fetch-wikimedia-commons:
 	@wget $(WGET_OPTIONS) "https://upload.wikimedia.org/wikipedia/commons/a/a1/Spain_languages-de.svg" --directory-prefix $(WIKIMEDIA_DIR)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ SVGO Test Suite includes files from the following sources. We use [REUSE](https:
 
 * [W3C SVG 1.1 Test Suite](https://www.w3.org/Graphics/SVG/Test/20110816/)
 * [KDE Oxygen Icons](https://download.kde.org/stable/frameworks/5.116/oxygen-icons-5.116.0.tar.xz.mirrorlist)
+* [Charm Icons](https://github.com/jaynewey/charm-icons)
 * [Wikimedia Commons](https://commons.wikimedia.org/wiki/Category:Large_SVG_files)
 
 ## Processing

--- a/static/REUSE.toml
+++ b/static/REUSE.toml
@@ -11,6 +11,11 @@ SPDX-FileCopyrightText = "See AUTHORS, COPYING, and COPYING.LIB in oxygen-icons-
 SPDX-License-Identifier = "LicenseRef-oxygen-icons-LGPL-3.0-only"
 
 [[annotations]]
+path = "charm-icons-*/**"
+SPDX-FileCopyrightText = "Copyright (c) 2021 Jay Newey"
+SPDX-License-Identifier = "MIT"
+
+[[annotations]]
 path = "W3C_SVG_11_TestSuite/**"
 precedence = "override"
 SPDX-FileCopyrightText = "Copyright © 2023 World Wide Web Consortium. All Rights Reserved. https://www.w3.org/copyright/test-suite-license-2023/"


### PR DESCRIPTION
This PR adds [Charm Icons](https://github.com/jaynewey/charm-icons), a set of stroke-based icons. Charm Icons is so minimal that it uses `v0`, a command currently mishandled by SVGO.

I was originally going to use Iconify when i saw [1 closed issue](https://github.com/svg/svgo/issues/1775) and [1 open issue](https://github.com/svg/svgo/issues/2158) that spoke of Iconify, but unfortunately, you can't actually reuse Iconify code to get pre-optimization icons (see https://github.com/iconify/icon-sets/issues/7#issuecomment-622952960, https://github.com/iconify/icon-sets/issues/102#issuecomment-1846800889), and the closed issue is for loaders (which can't be easily tested upon). So Charm Icons it is.